### PR TITLE
Logging

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,4 @@ branch = True
 source = app
 omit =
     main.py
+    app/logging/__init__.py

--- a/app/logging/__init__.py
+++ b/app/logging/__init__.py
@@ -1,0 +1,13 @@
+import logging  # Standard Python module for logging events and messages.
+# Documentation: https://docs.python.org/3/library/logging.html
+
+def setup_logging():
+    """Configure the logging settings for the application."""
+    logging.basicConfig(
+        filename='calculator.log',
+        level=logging.DEBUG,
+        format='%(asctime)s - %(levelname)s - %(message)s'
+    )
+
+# This allows other modules to import the setup_logging function directly
+__all__ = ['setup_logging']

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@
 # IMPORTING NECESSARY MODULES
 # ==============================================================================
 
+from app.logging import setup_logging
 import logging  # Standard Python module for logging events and messages.
 # Documentation: https://docs.python.org/3/library/logging.html
 
@@ -19,21 +20,7 @@ from dataclasses import dataclass  # Provides a decorator and functions for auto
 from typing import List  # Provides support for type hints.
 # Documentation: https://docs.python.org/3/library/typing.html
 
-# ==============================================================================
-# SETUP LOGGING CONFIGURATION
-# ==============================================================================
-
-# Configure the logging settings for the application.
-# Logging is crucial for tracking events and diagnosing issues in applications.
-logging.basicConfig(
-    filename='calculator.log',  # Specifies the file to write log messages to.
-    level=logging.DEBUG,  # Sets the logging level to DEBUG; captures all levels (DEBUG, INFO, WARNING, ERROR, CRITICAL).
-    format='%(asctime)s - %(levelname)s - %(message)s'  # Defines the format of the log messages.
-    # Format placeholders:
-    # %(asctime)s - Timestamp of the log entry.
-    # %(levelname)s - Severity level of the log message.
-    # %(message)s - The actual log message.
-)
+setup_logging()
 
 # ==============================================================================
 # OPERATION CLASSES (COMMAND AND TEMPLATE METHOD PATTERNS)


### PR DESCRIPTION
This change modularizes the logging configuration without significantly altering the structure of `main.py`. The logging setup is now in its own module, making it easier to maintain and potentially reuse in other parts of the application if needed.

To use this new logging setup in other parts of the application, you would simply need to import the `logging` module as usual. The configuration will be applied globally once `setup_logging()` is called in `main.py`.

This approach keeps the main file clean while separating concerns and improving modularity. The logging configuration is now in its own dedicated module, making it easier to modify or extend in the future without touching the main application logic.