### PR TITLE
specify path with dotenv_path

### DIFF
--- a/app/logging/__init__.py
+++ b/app/logging/__init__.py
@@ -1,15 +1,16 @@
 # app/logging/__init__.py
-
 import logging
 import os
-from dotenv import load_dotenv  # type: ignore
+from dotenv import load_dotenv
 from logging.handlers import RotatingFileHandler
 
-load_dotenv()
+# Specify the path to the .env file
+dotenv_path = os.path.join(os.path.dirname(__file__), '..', 'factory', '.env')
+load_dotenv(dotenv_path)
 
 def setup_logging() -> None:
     """Configure the logging settings for the application."""
-    log_filename: str = os.getenv('LOG_FILENAME', 'calculator20.log')  # Use a consistent default
+    log_filename: str = os.getenv('LOG_FILENAME', 'calculator_rename.log')  # Use a consistent default
     log_level_str: str = os.getenv('LOG_LEVEL', 'DEBUG').upper()
     log_format: str = os.getenv('LOG_FORMAT', '%(asctime)s - %(levelname)s - %(name)s - %(message)s')
     max_bytes: int = int(os.getenv('LOG_MAX_BYTES', 5 * 1024 * 1024))  # 5 MB
@@ -19,21 +20,14 @@ def setup_logging() -> None:
     log_level = getattr(logging, log_level_str, logging.DEBUG)
     
     # Create a rotating file handler
-    handler = RotatingFileHandler(
-        filename=log_filename,
-        maxBytes=max_bytes,
-        backupCount=backup_count
-    )
-    handler.setLevel(log_level)
+    handler = RotatingFileHandler(log_filename, maxBytes=max_bytes, backupCount=backup_count)
     formatter = logging.Formatter(log_format)
     handler.setFormatter(formatter)
     
-    # Get the root logger and configure it
-    root_logger = logging.getLogger()
-    root_logger.setLevel(log_level)
-    root_logger.addHandler(handler)
+    # Configure the root logger
+    logging.getLogger().setLevel(log_level)
+    logging.getLogger().addHandler(handler)
     
-    logger = logging.getLogger(__name__)
-    logger.debug(f"Logging configured with filename='{log_filename}', level='{log_level_str}', format='{log_format}', max_bytes={max_bytes}, backup_count={backup_count}")
+    logging.debug(f"Logging initialized with filename={log_filename}, level={log_level_str}")
 
 __all__ = ['setup_logging']


### PR DESCRIPTION
Fixed issue where `.env` was not loading properly due to not specifying the correct path. 